### PR TITLE
Added trick to show the camera at first launch. Changed target sdk

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="net.vplay.demos.qtws2017" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.3" android:versionCode="26" android:installLocation="auto">
+<manifest package="net.vplay.demos.qtws2017" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.4" android:versionCode="26" android:installLocation="auto">
     <application android:hardwareAccelerated="true" android:name="net.vplay.helper.VPlayApplication" android:label="@string/app_name" android:icon="@drawable/ic_launcher" android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="net.vplay.helper.VPlayActivity" android:label="@string/app_name" android:screenOrientation="sensor" android:launchMode="singleTop">
             <intent-filter>
@@ -46,7 +46,7 @@
             <!-- auto screen scale factor -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16"/>
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/qml/QtWSMain.qml
+++ b/qml/QtWSMain.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import Felgo 3.0
+import QtMultimedia 5.9
 import "pages"
 import "common"
 
@@ -57,4 +58,15 @@ App {
 
   // loads and holds actual app content
   QtWSLoaderItem { id: loaderItem }
+
+    Camera {
+        id: camera
+    }
+
+    VideoOutput {
+        anchors.fill: parent
+        source: camera
+        autoOrientation: true
+        visible: false
+    }
 }


### PR DESCRIPTION
version 1.4 Android
With the currente version if the user install the app from the google store, he see the message that it's and old app, but the main problem is that the first time that the user try to scan a QR Code the camera is not showed. I added a trick to avoid this problrm
